### PR TITLE
Remove aem service dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ Additionally, the role expects the `conga_packages` variable to be set by the [c
 
 ## Dependencies
 
-This role depends on the [conga-facts](https://github.com/wcm-io-devops/ansible-conga-facts) role for supplying the list of packages to install. It also depends on the [ansible-aem-service](https://github.com/wcm-io-devops/ansible-aem-service) role for ensuring that the target AEM instance is started and restarting it if the package metadata declares that it is required.
+This role depends on the
+[conga-facts](https://github.com/wcm-io-devops/ansible-conga-facts) role
+for supplying the list of packages to install. It also depends on a role
+that provides a handler named "aem restart". This handler is normally
+provided by the
+[ansible-aem-service](https://github.com/wcm-io-devops/ansible-aem-service)
+role, which is used by the conga ansible automation when using the
+[ansible-conga-aem-cms](https://github.com/wcm-io-devops/ansible-conga-aem-cms) role.
 
 ## Example Playbook
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,6 +28,3 @@ galaxy_info:
 allow_duplicates: yes
 dependencies:
   - conga-facts
-  - { name: aem-service,
-      aem_service_port: "{{ conga_aem_packages_port }}",
-      aem_service_name: "{{ aem_cms_service_name }}" }


### PR DESCRIPTION
Due to a bug in ansible the "aem restart handler" is executed twice after initial instance setup because the roles
* https://github.com/wcm-io-devops/ansible-conga-aem-cms
* https://github.com/wcm-io-devops/ansible-conga-bundle-files and
* https://github.com/wcm-io-devops/ansible-conga-aem-packages

included the https://github.com/wcm-io-devops/ansible-aem-service role as dependency.
The dependency of https://github.com/wcm-io-devops/ansible-conga-bundle-files was already removed with: https://github.com/wcm-io-devops/ansible-conga-bundle-files/pull/1
