### PR TITLE
Adds support for bundle controlled installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ The port of the target AEM instance. It defaults to the port configured in the [
 
 The  package manager service URL the Maven plugin uses to poll the package state.
 
+    conga_aem_bundle_status_url: "http://{{ inventory_hostname }}:{{ conga_aem_packages_port }}/system/console/bundles.json"
+
+Bundle status URL to poll while waiting for installation is complete when package is using a installer bundle (like AEM 6.3 SP2).
+
+    conga_aem_bundle_status_timeout: 600
+
+Timeout to wait (10 minutes per default) for installer bundle to be removed.
+
+    conga_aem_bundle_status_retry_delay: 10
+
+The retry delay for calling the `conga_aem_bundle_status_url`.
+
 Additionally, the role expects the `conga_packages` variable to be set by the [conga-facts](https://github.com/wcm-io-devops/ansible-conga-facts) role (on which this role depends) to the list of packages from the CONGA configuration model.
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,9 +16,9 @@ conga_aem_packages_password: admin
 conga_aem_packages_port: "{{ conga_config.quickstart.port }}"
 conga_aem_packages_service_url: "http://{{ inventory_hostname }}:{{ conga_aem_packages_port }}/crx/packmgr/service"
 
-# Bundle status URL to poll while waiting for installation is complete when package is using a installer bundle
+# Bundle status URL to poll while waiting for installation is complete when package is using a installer bundle (like AEM 6.3 SP2).
 conga_aem_bundle_status_url: "http://{{ inventory_hostname }}:{{ conga_aem_packages_port }}/system/console/bundles.json"
-# timeout to wait (10 minutes per default)
+# Timeout to wait (10 minutes per default) for installer bundle to be removed.
 conga_aem_bundle_status_timeout: 600
-# retry delay
+# The retry delay for calling the `conga_aem_bundle_status_url`.
 conga_aem_bundle_status_retry_delay: 10

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,10 @@ conga_aem_packages_password: admin
 # Port and package manager service URL of the AEM instance
 conga_aem_packages_port: "{{ conga_config.quickstart.port }}"
 conga_aem_packages_service_url: "http://{{ inventory_hostname }}:{{ conga_aem_packages_port }}/crx/packmgr/service"
+
+# Bundle status URL to poll while waiting for installation is complete when package is using a installer bundle
+conga_aem_bundle_status_url: "http://{{ inventory_hostname }}:{{ conga_aem_packages_port }}/system/console/bundles.json"
+# timeout to wait (10 minutes per default)
+conga_aem_bundle_status_timeout: 600
+# retry delay
+conga_aem_bundle_status_retry_delay: 10

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -7,6 +7,9 @@
     _item_vault_force_define: "-Dvault.force={{ item.force }}"
   when: item.force is defined
 
+- pause:
+    prompt: "Continue Deploying AEM package: {{ item.path | basename }}?"
+
 - name: "Deploy AEM package: {{ item.path | basename }}"
   shell: >
     {{ conga_aem_packages_maven_cmd }}
@@ -30,6 +33,25 @@
   fail:
     msg: "{{ _mvn_result }}"
   when: _mvn_result.stdout is undefined
+
+- name: "Wait for installer bundle '{{ item.installerBundle }}' to be uninstalled (installation complete)"
+  uri:
+    url: "{{ conga_aem_bundle_status_url }}"
+    return_content: yes
+    force_basic_auth: yes
+    user: "{{ conga_aem_packages_user }}"
+    password: "{{ conga_aem_packages_password }}"
+    status_code: -1,200
+  register: result
+  until:
+    - result.content != ""
+    - result.content.find(item.installerBundle) == -1
+  retries: "{{ conga_aem_bundle_status_timeout // conga_aem_bundle_status_retry_delay }}"
+  delay: "{{ conga_aem_bundle_status_retry_delay }}"
+  when:
+    - item.installerBundle is defined
+    - item.installerBundle != ""
+    - conga_aem_packages_changed_output in _mvn_result.stdout
 
   # Restart if the package has actually been installed and it has been declared as necessary and
   # allow overriding the requiresRestart property from the package metadata in the CONGA configuration

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -7,9 +7,6 @@
     _item_vault_force_define: "-Dvault.force={{ item.force }}"
   when: item.force is defined
 
-- pause:
-    prompt: "Continue Deploying AEM package: {{ item.path | basename }}?"
-
 - name: "Deploy AEM package: {{ item.path | basename }}"
   shell: >
     {{ conga_aem_packages_maven_cmd }}


### PR DESCRIPTION
With AEM 6.3 Servicepack 2 a new mechanism was introduced which is based upon a bundle that seems to control the installation.

This new mechanism is currently not covered [wcm.io Content Package Maven Plugin](http://wcm.io/tooling/maven/plugins/wcmio-content-package-maven-plugin/) which results in a way to early response that the Installation is complete.

On our testinstances the installation goes on for more than 3 minutes after the bundles are all started.

So i implemented a mechanism that waits for a bundle to be removed/uninstalled after the package was installed using wcm.io tooling.

This property can be easily set in the role definition:

```
- url: mvn:adobe.binary.aem.63.servicepack/AEM-6.3-Service-Pack-2/6.3.2/zip
  dir: packages
  modelOptions:
    delayAfterInstallSec: 30
    installerBundle: updater.aem-service-pkg
    requiresRestart: true
```