### PR TITLE
Adds support for versionInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Name of the Maven executable to use.
 
 	conga_aem_packages_wcmio_content_package_maven_plugin_version: 1.6.0
 
-The version of the wcm.io content package maven plugin to use.
+The default version of the wcm.io content package maven plugin to use.
+If a version is specified for `io.wcm.maven.plugins:wcmio-content-package-maven-plugin` in the `conga_version_info` fact (provided by [conga-facts](https://github.com/wcm-io-devops/ansible-conga-facts)) this value will be overridden.
 
 	conga_aem_packages_wcmio_content_package_maven_plugin_changed_output: "Package installed"
 
@@ -49,10 +50,9 @@ Additionally, the role expects the `conga_packages` variable to be set by the [c
 
 This role depends on the
 [conga-facts](https://github.com/wcm-io-devops/ansible-conga-facts) role
-for supplying the list of packages to install. It also depends on a role
-that provides a handler named "aem restart". This handler is normally
-provided by the
-[ansible-aem-service](https://github.com/wcm-io-devops/ansible-aem-service)
+for supplying the list of packages to install and the wcmio-content-package-maven-plugin to use.
+It also depends on a role that provides a handler named "aem restart". This handler is normally
+provided by the [ansible-aem-service](https://github.com/wcm-io-devops/ansible-aem-service)
 role, which is used by the conga ansible automation when using the
 [ansible-conga-aem-cms](https://github.com/wcm-io-devops/ansible-conga-aem-cms) role.
 

--- a/README.md
+++ b/README.md
@@ -32,18 +32,6 @@ The port of the target AEM instance. It defaults to the port configured in the [
 
 The  package manager service URL the Maven plugin uses to poll the package state.
 
-    conga_aem_bundle_status_url: "http://{{ inventory_hostname }}:{{ conga_aem_packages_port }}/system/console/bundles.json"
-
-Bundle status URL to poll while waiting for installation is complete when package is using a installer bundle (like AEM 6.3 SP2).
-
-    conga_aem_bundle_status_timeout: 600
-
-Timeout to wait (10 minutes per default) for installer bundle to be removed.
-
-    conga_aem_bundle_status_retry_delay: 10
-
-The retry delay for calling the `conga_aem_bundle_status_url`.
-
 Additionally, the role expects the `conga_packages` variable to be set by the [conga-facts](https://github.com/wcm-io-devops/ansible-conga-facts) role (on which this role depends) to the list of packages from the CONGA configuration model.
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,10 +15,3 @@ conga_aem_packages_password: admin
 # Port and package manager service URL of the AEM instance
 conga_aem_packages_port: "{{ conga_config.quickstart.port }}"
 conga_aem_packages_service_url: "http://{{ inventory_hostname }}:{{ conga_aem_packages_port }}/crx/packmgr/service"
-
-# Bundle status URL to poll while waiting for installation is complete when package is using a installer bundle (like AEM 6.3 SP2).
-conga_aem_bundle_status_url: "http://{{ inventory_hostname }}:{{ conga_aem_packages_port }}/system/console/bundles.json"
-# Timeout to wait (10 minutes per default) for installer bundle to be removed.
-conga_aem_bundle_status_timeout: 600
-# The retry delay for calling the `conga_aem_bundle_status_url`.
-conga_aem_bundle_status_retry_delay: 10

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ conga_aem_packages_maven_host: "{{ conga_host | default('localhost') }}"
 # Maven executable to use
 conga_aem_packages_maven_cmd: "{{ conga_maven_cmd | default('mvn') }}"
 
-# Version of the wcm.io content package maven plugin to use
+# Version of the wcm.io content package maven plugin to use when no version info is provided by conga_facts
 conga_aem_packages_wcmio_content_package_maven_plugin_version: 1.6.0
 # Output to expect when a package was actually installed/changed
 conga_aem_packages_wcmio_content_package_maven_plugin_changed_output: "Package installed"

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -7,10 +7,16 @@
     _item_vault_force_define: "-Dvault.force={{ item.force }}"
   when: item.force is defined
 
+- name: "Set environment specific wcmio-content-package-maven-plugin version"
+  set_fact:
+    _conga_aem_packages_wcmio_content_package_maven_plugin_version: "{{ conga_version_info['io.wcm.maven.plugins:wcmio-content-package-maven-plugin'] | default(conga_aem_packages_wcmio_content_package_maven_plugin_version)}}"
+  changed_when:
+    _conga_aem_packages_wcmio_content_package_maven_plugin_version != conga_aem_packages_wcmio_content_package_maven_plugin_version
+
 - name: "Deploy AEM package: {{ item.path | basename }}"
   shell: >
     {{ conga_aem_packages_maven_cmd }}
-    io.wcm.maven.plugins:wcmio-content-package-maven-plugin:{{ conga_aem_packages_wcmio_content_package_maven_plugin_version }}:install
+    io.wcm.maven.plugins:wcmio-content-package-maven-plugin:{{ _conga_aem_packages_wcmio_content_package_maven_plugin_version }}:install
     -Dvault.serviceURL={{ conga_aem_packages_service_url }}
     -Dvault.file={{ item.path }}
     -Dvault.userId={{ conga_aem_packages_user }}

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -37,25 +37,6 @@
     msg: "{{ _mvn_result }}"
   when: _mvn_result.stdout is undefined
 
-- name: "Wait for installer bundle '{{ item.installerBundle }}' to be uninstalled (installation complete)"
-  uri:
-    url: "{{ conga_aem_bundle_status_url }}"
-    return_content: yes
-    force_basic_auth: yes
-    user: "{{ conga_aem_packages_user }}"
-    password: "{{ conga_aem_packages_password }}"
-    status_code: -1,200
-  register: result
-  until:
-    - result.content != ""
-    - result.content.find(item.installerBundle) == -1
-  retries: "{{ conga_aem_bundle_status_timeout // conga_aem_bundle_status_retry_delay }}"
-  delay: "{{ conga_aem_bundle_status_retry_delay }}"
-  when:
-    - item.installerBundle is defined
-    - item.installerBundle != ""
-    - conga_aem_packages_wcmio_content_package_maven_plugin_changed_output in _mvn_result.stdout
-
   # Restart if the package has actually been installed and it has been declared as necessary and
   # allow overriding the requiresRestart property from the package metadata in the CONGA configuration
 - name: Restart AEM if required by package metadata.


### PR DESCRIPTION
This PR adds the support for the new versionInfo section which contains information about the mvn plugins used generating the conga configuration.

When a version for the `io.wcm.maven.plugins:wcmio-content-package-maven-plugin` is present this version is used, otherwise the default version specified in `conga_aem_packages_wcmio_content_package_maven_plugin_version`  is used.

Depends on:
* https://github.com/wcm-io-devops/ansible-conga-facts/pull/3