### PR TITLE
Fix default conga_aem_packages_maven_logfile location

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ package state.
 
 When set to true the mvn stdout will be tee'd into a log file for debug purposes.
 
-    conga_aem_packages_maven_logfile: "{{ conga_config_path }}/conga-aem-packages-mvn.log"
+    conga_aem_packages_maven_logfile: "conga-aem-packages-mvn.log"
 
-The path to the log file, per default this is placed in the configuration directory of the conga node.
+The path to the log file, location is relative to 'conga_config_path', which is the directory of the conga node.
 
     conga_aem_packages_standalone: true 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,8 +24,8 @@ conga_aem_packages_service_url: "http://{{ inventory_hostname }}:{{ conga_aem_pa
 # When set to true the mvn stdout will be tee'd into a log file for debug purposes
 conga_aem_packages_maven_logging: false
 
-# The path to the log file, per default this is placed in the configuration directory of the conga node
-conga_aem_packages_maven_logfile: "{{ conga_config_path }}/conga-aem-packages-mvn.log"
+# The path to the log file, location is relative to 'conga_config_path', which is the directory of the conga node
+conga_aem_packages_maven_logfile: "conga-aem-packages-mvn.log"
 
 # Enables/disables standalone mode
 conga_aem_packages_standalone: true


### PR DESCRIPTION
Maven is running in `conga_config_path` so `conga_aem_packages_maven_logfile` is relative to this path.