### PR TITLE
Add filter based interactive mode for package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Enables/disables standalone mode. When set to true the
 enabled. Set this value to false when you have several aem-service
 dependencies in your play to avoid multiple AEM restarts.
 
+    #conga_aem_packages_interactive_packages:
+    # - AEM-6.4.2.0-6.4.2.zip # prompt for package with the name 'AEM-6.4.2.0-6.4.2.zip'
+
+When set the deployment for each matching package has to be confirmed by
+the user.
+
 Additionally, the role expects the `conga_packages` variable to be set
 by the
 [wcm_io_devios.conga_facts](https://github.com/wcm-io-devops/ansible-conga-facts) role

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,7 @@ conga_aem_packages_maven_logfile: "conga-aem-packages-mvn.log"
 
 # Enables/disables standalone mode
 conga_aem_packages_standalone: true
+
+# When set the deployment for each matching package has to be confirmed by the user.
+#conga_aem_packages_interactive_packages:
+# - AEM-6.4.2.0-6.4.2.zip # prompt for package with the name 'AEM-6.4.2.0-6.4.2.zip'

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -28,6 +28,13 @@
   changed_when:
     _conga_aem_packages_wcmio_content_package_maven_plugin_version != conga_aem_packages_wcmio_content_package_maven_plugin_version
 
+- name: "Use interactive mode for '{{ item.path | basename }}'"
+  pause:
+    prompt: "Continue with deploying {{ item.path | basename }}?"
+  when:
+    - conga_aem_packages_interactive_packages is defined
+    - (item.path | basename) in conga_aem_packages_interactive_packages
+
 - name: "Deploy AEM package: {{ item.path | basename }}"
   shell: >
     {{ conga_aem_packages_maven_cmd }}


### PR DESCRIPTION
This feature is useful when executing a deployment locally and you want more control over the packate installation flow.