### PR TITLE
Ansible 2.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,16 @@ the user.
 
 Additionally, the role expects the `conga_packages` variable to be set
 by the
-[wcm_io_devios.conga_facts](https://github.com/wcm-io-devops/ansible-conga-facts) role
-(on which this role depends) to the list of packages from the CONGA
+[wcm_io_devios.conga_facts](https://github.com/wcm-io-devops/ansible-conga-facts)
+role (on which this role depends) to the list of packages from the CONGA
 configuration model.
+
+# Result facts
+
+    conga_aem_packages_aem_restarted
+
+This fact has the value `true` when the AEM instance was restarted
+during package installation.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ by the
 role (on which this role depends) to the list of packages from the CONGA
 configuration model.
 
-# Result facts
+## Result facts
 
     conga_aem_packages_aem_restarted
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ conga_aem_packages_maven_opts: "-B -U"
 
 
 # Version of the wcm.io content package maven plugin to use when no version info is provided by conga_facts
-conga_aem_packages_wcmio_content_package_maven_plugin_version: 1.7.2
+conga_aem_packages_wcmio_content_package_maven_plugin_version: 1.8.4
 # Output to expect when a package was actually installed/changed
 conga_aem_packages_wcmio_content_package_maven_plugin_changed_output: "Package installed"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -36,5 +36,6 @@ dependencies:
       version: 1.2.0,
       aem_service_port: "{{ conga_aem_packages_port }}",
       aem_service_name: "{{ aem_cms_service_name }}",
+      aem_service_state: "started",
       when: conga_aem_packages_standalone
     }

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -67,12 +67,11 @@
   # Restart if the package has actually been installed and it has been declared as necessary and
   # allow overriding the requiresRestart property from the package metadata in the CONGA configuration
 - name: Restart AEM if required by package metadata.
-  command: /bin/true
-  notify: restart aem
+  include_role:
+    name: wcm_io_devops.aem_service
+  vars:
+    aem_service_state: restarted
   when: (conga_aem_packages_wcmio_content_package_maven_plugin_changed_output in _mvn_result.stdout) and
         (item.requiresRestart |
          default(item.aemContentPackageProperties.requiresRestart is defined and
          item.aemContentPackageProperties.requiresRestart | bool))
-
-- name: Flush pending (restart) handlers before installation of next package.
-  meta: flush_handlers

--- a/tasks/install_package.yml
+++ b/tasks/install_package.yml
@@ -64,13 +64,22 @@
     msg: "{{ _mvn_result }}"
   when: _mvn_result.stdout is not defined or _mvn_result.stdout.find('BUILD FAILURE') != -1
 
-  # Restart if the package has actually been installed and it has been declared as necessary and
-  # allow overriding the requiresRestart property from the package metadata in the CONGA configuration
-- name: Restart AEM if required by package metadata.
-  include_role:
-    name: wcm_io_devops.aem_service
-  vars:
-    aem_service_state: restarted
+
+  # execute tasks required on restart
+- block:
+
+    # Restart if the package has actually been installed and it has been declared as necessary and
+    # allow overriding the requiresRestart property from the package metadata in the CONGA configuration
+  - name: Restart AEM if required by package metadata.
+    include_role:
+      name: wcm_io_devops.aem_service
+    vars:
+      aem_service_state: restarted
+
+  - name: "Set 'conga_aem_packages_aem_restarted' to true when changed."
+    set_fact:
+      conga_aem_packages_aem_restarted: true
+
   when: (conga_aem_packages_wcmio_content_package_maven_plugin_changed_output in _mvn_result.stdout) and
         (item.requiresRestart |
          default(item.aemContentPackageProperties.requiresRestart is defined and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
-- name: Setup packages list.
+- name: Setup packages list and result facts.
   set_fact:
     _packages: "{{ packages | default(conga_packages) }}"
+    conga_aem_packages_aem_restarted: false
 
 - name: "Deploy AEM packages for role: {{ conga_role }}"
   include_tasks: install_package.yml


### PR DESCRIPTION
Ansible 2.8+ changed somehow the behavior of the handlers. The used mechanism for restarting the AEM instance by flushing the handlers after the package installation does not work anymore. Beside that flushing of the handlers is bad practice because it is not only flushing our handlers, it is flushing all registered handlers.

To restart the AEM instance if a package requires this after a successful installation we are not using `incluce_role` to restart the AEM instance uring [wcm_io_devops.aem_service](https://github.com/wcm-io-devops/ansible-aem-service).

This PR introduces the result fact `conga_aem_packages_aem_restarted` which can be `true` or `false`.
When the AEM instance was restarted during the package installation process this value will be set to true. The result will then be used by the role wcm_io_devops.conga_aem_cms to determine if a restart is required or not.